### PR TITLE
fix issue with example due to None for userId

### DIFF
--- a/src/examples/python/create_and_register_user.py
+++ b/src/examples/python/create_and_register_user.py
@@ -30,7 +30,7 @@ user_registration_request = {
     'skipVerification': False
 }
 
-client_response = client.register(None, user_registration_request)
+client_response = client.register(user_registration_request)
 if client_response.was_successful():
     print(client_response.success_response)
 else:


### PR DESCRIPTION
If `None` is present, we obtain an error:

```
{
    "fieldErrors":{
        "registration":[
            {
                "code":"[missing]registration",
                "message":"Your request is missing the Registration information as JSON in the entity-body."
            }
        ],
        "userId":[
            {
                "code":"[couldNotConvert]userId",
                "message":"Invalid userId [{'registration': {'applicationId': '194db1ce-9951-446d-8ec1-ff0bdfda6cfe'}, 'user': {'birthDate': '1976-05-30', 'email': 'john@doe.io', 'password': 'password', 'firstName': 'John', 'lastName': 'Doe', 'twoFactorEnabled': False, 'username': 'johnny123'}, 'sendSetPasswordEmail': False, 'skipVerification': True}]. This must be a valid UUID String (e.g. 25a872da-bb44-4af8-a43d-e7bcb5351ebc)."
            }
        ]
    }
}
```