### PR TITLE
:sparkles: Add inactive parameter on retrieve_applications

### DIFF
--- a/src/main/python/fusionauth/fusionauth_client.py
+++ b/src/main/python/fusionauth/fusionauth_client.py
@@ -2259,13 +2259,15 @@ class FusionAuthClient:
             .get() \
             .go()
 
-    def retrieve_applications(self):
+    def retrieve_applications(self, inactive=False):
         """
         Retrieves all the applications.
 
         Attributes:
+            inactive: (Optional) Retrieves all inactive Applications instead.
         """
-        return self.start().uri('/api/application') \
+        return self.start().uri(f'/api/application') \
+            .url_parameter('inactive', self.convert_true_false(inactive)) \
             .get() \
             .go()
 

--- a/src/test/docker/kickstart/kickstart.json
+++ b/src/test/docker/kickstart/kickstart.json
@@ -3,7 +3,8 @@
     "adminEmail": "admin@fusionauth.io",
     "password": "password",
     "defaultTenantId": "30663132-6464-6665-3032-326466613934",
-    "piedPiperApplicationId": "85a03867-dccf-4882-adde-1a79aeec50df"
+    "piedPiperApplicationId": "85a03867-dccf-4882-adde-1a79aeec50df",
+    "inactiveAppId": "d915faae-c0f0-4032-9912-0daee4e65d58"
   },
   "apiKeys": [
     {
@@ -18,6 +19,31 @@
       "body": {
         "application": {
           "name": "Pied Piper",
+          "roles": [
+            {
+              "name": "dev"
+            },
+            {
+              "name": "ceo"
+            },
+            {
+              "name": "intern"
+            }
+          ],
+          "loginConfiguration": {
+            "generateRefreshTokens": true
+          }
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "url": "/api/application/#{inactiveAppId}",
+      "body": {
+        "application": {
+          "state": "Inactive",
+          "active": false,
+          "name": "Inactive Application",
           "roles": [
             {
               "name": "dev"

--- a/src/test/python/fusionauth/fusionauth_client_test.py
+++ b/src/test/python/fusionauth/fusionauth_client_test.py
@@ -49,7 +49,22 @@ class FusionAuthClientTest(unittest2.TestCase):
     def test_retrieve_applications(self):
         client_response = self.client.retrieve_applications()
         self.assertEqual(client_response.status, 200)
-        self.assertEqual(len(client_response.success_response['applications']), 2)
+        self.assertEqual(len(client_response.success_response['applications']), 3)
+
+        # pick up the application that should be inactive and deactivate it.
+        should_be_inactive_app = next((application for application in client_response.success_response['applications'] if application['name'] == 'Inactive Application'))
+        self.client.deactivate_application(should_be_inactive_app['id'])
+
+        active_applications = self.client.retrieve_applications()
+        self.assertEqual(active_applications.status, 200)
+        self.assertEqual(len(active_applications.success_response['applications']), 2)
+
+        inactive_response = self.client.retrieve_applications(inactive=True)
+        self.assertEqual(inactive_response.status, 200)
+        self.assertEqual(len(inactive_response.success_response['applications']), 1)
+
+        # Reactivate the application so it don't break when we run this test again.
+        self.client.reactivate_application(should_be_inactive_app['id'])
 
     def test_create_user_retrieve_user(self):
         # Check if the user already exists.


### PR DESCRIPTION
This PR adds the possibility of retrieving all inactive applications, by making use of the "inactive" parameter.